### PR TITLE
Fix change variable names

### DIFF
--- a/packages/core/src/components/base/Button/index.tsx
+++ b/packages/core/src/components/base/Button/index.tsx
@@ -57,11 +57,13 @@ const Button: FC<IButtonProps> = ({
       {...props}
       disabled={disabled}
     >
-      {variant !== 'icon' && (
+      {variant !== 'icon' && startIcon && (
         <span className={styles.startIcon}>{startIcon}</span>
       )}
       {children}
-      {variant !== 'icon' && <span className={styles.endIcon}>{endIcon}</span>}
+      {variant !== 'icon' && endIcon && (
+        <span className={styles.endIcon}>{endIcon}</span>
+      )}
     </button>
   );
 };

--- a/packages/core/src/components/base/Chip/README.md
+++ b/packages/core/src/components/base/Chip/README.md
@@ -6,8 +6,8 @@
 |-----------|-------------------------------------------------------------------------------------|-------------------------------|-----------|:---------:|
 | text      | The displayed text inside the component                                             | string                        |           |    Yes    |
 | variant   | Chips appearance<br>- 'default'<br>- 'toggle': the component can be clicked to toggle | 'default' \| 'toggle'         | 'default' |     No    |
-| prefix    | Element before text (string is also supported)                                      | ReactNode                     |           |     No    |
-| suffix    | Element after text (string is also supported)                                       | ReactNode                     |           |     No    |
+| startAdornment    | Element before text (string is also supported)                                      | ReactNode                     |           |     No    |
+| endAdornment    | Element after text (string is also supported)                                       | ReactNode                     |           |     No    |
 | disabled  | Whether this component should be disabled                                           | boolean                       | false     |     No    |
 | onChange  | A function that triggers every changes                                              | (isSelected: boolean) => void |           |    No    |
 | className | Class name for overriding Chip's style                                              | string                        |           |     No    |

--- a/packages/core/src/components/base/Chip/index.tsx
+++ b/packages/core/src/components/base/Chip/index.tsx
@@ -8,16 +8,16 @@ export interface IChipProps {
   text: string;
   className?: string;
   disabled?: boolean;
-  prefix?: ReactNode;
-  suffix?: ReactNode;
+  startAdornment?: ReactNode;
+  endAdornment?: ReactNode;
   variant?: 'default' | 'toggle';
   onChange?: (isSelected: boolean) => void;
 }
 
 const Chip: FC<IChipProps> = ({
   text,
-  prefix,
-  suffix,
+  startAdornment,
+  endAdornment,
   onChange,
   variant = 'default',
   disabled = false,
@@ -43,10 +43,12 @@ const Chip: FC<IChipProps> = ({
       }}
     >
       <div className={styles.content}>
-        {prefix && <div className={styles.prefix}>{prefix}</div>}
+        {startAdornment && (
+          <div className={styles.prefix}>{startAdornment}</div>
+        )}
         {text}
       </div>
-      {suffix && <div className={styles.suffix}>{suffix}</div>}
+      {endAdornment && <div className={styles.suffix}>{endAdornment}</div>}
     </div>
   );
 };

--- a/packages/core/src/components/base/Input/Input.tsx
+++ b/packages/core/src/components/base/Input/Input.tsx
@@ -16,8 +16,8 @@ export interface IInputProps
     'prefix' | 'type' | 'size'
   > {
   className?: string;
-  prefix?: ReactNode;
-  suffix?: ReactNode;
+  startAdornment?: ReactNode;
+  endAdornment?: ReactNode;
   /**
    * L - 40px (desktop) / 48px (mobile)
    *
@@ -31,7 +31,7 @@ export interface IInputProps
 }
 
 const Input = forwardRef<HTMLInputElement | null, IInputProps>(
-  ({ className, prefix, suffix, size = 'L', ...props }, ref) => {
+  ({ className, startAdornment, endAdornment, size = 'L', ...props }, ref) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
     const handleClick = () => {
@@ -50,9 +50,11 @@ const Input = forwardRef<HTMLInputElement | null, IInputProps>(
         )}
         onClick={handleClick}
       >
-        {prefix && <div className={styles.prefix}>{prefix}</div>}
+        {startAdornment && (
+          <div className={styles.prefix}>{startAdornment}</div>
+        )}
         <input {...props} type="text" ref={mergeRefs([inputRef, ref])} />
-        {suffix && <div className={styles.suffix}>{suffix}</div>}
+        {endAdornment && <div className={styles.suffix}>{endAdornment}</div>}
       </div>
     );
   }

--- a/packages/core/src/components/base/Input/README.md
+++ b/packages/core/src/components/base/Input/README.md
@@ -15,8 +15,8 @@ This component consists of many small components by using jsx dot notation so pl
 | Name      | Description                                                                                                              | Types             | Default | Required? |
 |-----------|--------------------------------------------------------------------------------------------------------------------------|-------------------|---------|:---------:|
 | size      | Size of Input<br>- 'L': 40px (desktop) / 48px (mobile)<br>- 'M': 32px (desktop)<br>- 'S': 24px (desktop) / 36px (mobile) | 'S' \| 'M' \| 'L' | 'L'     |     No    |
-| prefix    | Element before value (string is also supported)                                                                            | ReactNode         |         |     No    |
-| suffix    | Element after value (string is also supported)                                                                             | ReactNode         |         |     No    |
+| startAdornment    | Element before value (string is also supported)                                                                            | ReactNode         |         |     No    |
+| endAdornment    | Element after value (string is also supported)                                                                             | ReactNode         |         |     No    |
 | className | Class name for overriding Input's style                                                                             | string            |         |     No    |
 
 Any HTML input attributes are also available


### PR DESCRIPTION
### What's changed:
- Fix unnecessary tag rendered on Button when `variant` is `icon`
- Change props name in `Input` and `Chip` from `prefix` => `startAdornment` and from `suffix` => `endAdornment`